### PR TITLE
Fixed KeyJ

### DIFF
--- a/src/Web/KeyCode.hs
+++ b/src/Web/KeyCode.hs
@@ -194,7 +194,7 @@ keyCodeMap = fromAscList [
     , ( 71, KeyG          )
     , ( 72, KeyH          )
     , ( 73, KeyI          )
-    , ( 74, KeyK          )
+    , ( 74, KeyJ          )
     , ( 75, KeyK          )
     , ( 76, KeyL          )
     , ( 77, KeyM          )


### PR DESCRIPTION
`KeyJ` was never being returned properly and the "j" key was being read as `KeyK`.

I'm surprised I happened to stumble onto this, haha. My use of Vim key bindings actually did benefit something!
